### PR TITLE
Update the selection color

### DIFF
--- a/dracula.xml
+++ b/dracula.xml
@@ -31,7 +31,7 @@ SOFTWARE.
 	<!-- Dracula colors -->
 	<color name="background" value="#282a36"/>
 	<color name="current-line" value="#44475a"/>
-	<color name="selection" value="#f8f8f2"/>
+	<color name="selection" value="#bd93f9"/>
 	<color name="foreground" value="#f8f8f2"/>
 	<color name="comment" value="#6272a4"/>
 	<color name="cyan" value="#8be9fd"/>

--- a/dracula.xml
+++ b/dracula.xml
@@ -31,7 +31,7 @@ SOFTWARE.
 	<!-- Dracula colors -->
 	<color name="background" value="#282a36"/>
 	<color name="current-line" value="#44475a"/>
-	<color name="selection" value="#44475a"/>
+	<color name="selection" value="#7c7e8b"/>
 	<color name="foreground" value="#f8f8f2"/>
 	<color name="comment" value="#6272a4"/>
 	<color name="cyan" value="#8be9fd"/>

--- a/dracula.xml
+++ b/dracula.xml
@@ -31,7 +31,7 @@ SOFTWARE.
 	<!-- Dracula colors -->
 	<color name="background" value="#282a36"/>
 	<color name="current-line" value="#44475a"/>
-	<color name="selection" value="#7c7e8b"/>
+	<color name="selection" value="#f8f8f2"/>
 	<color name="foreground" value="#f8f8f2"/>
 	<color name="comment" value="#6272a4"/>
 	<color name="cyan" value="#8be9fd"/>


### PR DESCRIPTION
Hello,

Currently, when the `Highlight current line` option is enable in Gedit preferences, the `selection` color from the theme is the same as the highlight color.

Thanks for your great job!