### PR TITLE
Add two versions of the theme and update install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,15 @@
 
 1. Download the raw file:
 
-    wget https://raw.githubusercontent.com/dracula/gedit/master/dracula.xml
+```
+wget https://raw.githubusercontent.com/dracula/gedit/master/dracula.xml
+```
+
+If your version of Gedit is 46 or newer, use the following command instead:
+
+```
+wget https://raw.githubusercontent.com/dracula/gedit/master/dracula-46.xml -O dracula.xml
+```
 
 2. Move the file to gedit style's folder:
 

--- a/dracula-46.xml
+++ b/dracula-46.xml
@@ -24,8 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 
-<style-scheme id="dracula" name="Dracula" version="1.0">
-	<author>Ricardo Madriz</author>
+<style-scheme id="dracula" name="Dracula" kind="dark">
 	<_description>A dark theme for Gedit</_description>
 
 	<!-- Dracula colors -->


### PR DESCRIPTION
**Description**

This is a fix for #12 where the existing version did not work on gedit v46+ and newer is not backwards compatible with v45 or previous versions. 

Fixes #12 