### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,3 +15,11 @@
     mv dracula.xml $HOME/.local/share/gedit/styles/
 
 3. Activate in Gedit's preferences dialog
+
+
+If it doesn't show up in the dialog:
+In some distributions it has to be moved to a different place
+
+    cp $HOME/.local/share/gedit/styles/dracula.xml /usr/share/libgedit-gtksourceview-300/styles/
+
+you'll need to to perform that action as root though (sudo)! 


### PR DESCRIPTION
For EndeavourOS with the Budgie Desktop (I don't know if EOS or Budgie is the reason) that location never works.
I searched for all the possible locations. Finally found out it has to be in '/usr/share/libgedit-gtksourceview-300/styles/' for gedit to show it as a possible Color Scheme. 

I am not sure if this is the right way to do it. Especially didn't know if I should have included sudo or su in another way or shouldn't even have mentioned it for security reasons. Also I'm not sure if a pull request was the correct way to bring up this issue. But I didn't want others to struggle like me with that issue. Sorry, if I bothered you and there was a better way to do this.